### PR TITLE
Added support for mem_dbg as optional feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ name = "accuracy"
 
 [dependencies]
 ahash = "0.8.11"
+mem_dbg = {version="0.2.4", optional=true}
 rand = { version = "0.8" }
 siphasher = { version = "1", optional = true }
 

--- a/src/h2b.rs
+++ b/src/h2b.rs
@@ -12,6 +12,7 @@ use crate::AHasherDefaultBuilder;
 /// different numbers of sub streams.
 ///
 /// Both the hasher and the sub stream size siaz can be customized, by default it uses `AHasherBuilder` and `M256`
+#[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemDbg, mem_dbg::MemSize))]
 pub struct HyperTwoBits<SKETCH: Sketch = M256, HASH: BuildHasher = AHasherDefaultBuilder> {
     hash: HASH,
     sketch: SKETCH,

--- a/src/h2b/sketch.rs
+++ b/src/h2b/sketch.rs
@@ -29,6 +29,7 @@ pub trait Sketch: Default {
 
 /// M = 64, using two 64 bit integers to store the sketch
 #[derive(Default)]
+#[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemDbg, mem_dbg::MemSize))]
 pub struct M64 {
     low: u64,
     high: u64,
@@ -99,6 +100,7 @@ impl Sketch for M64 {
 ///
 /// The implementation is similar to M64
 #[derive(Default)]
+#[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemDbg, mem_dbg::MemSize))]
 pub struct M128 {
     low: u128,
     high: u128,
@@ -169,6 +171,7 @@ struct HiLoRegister {
 ///
 /// This is not meant to be used directly instead it serves as
 /// a base for the other vectored sketches
+#[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemDbg, mem_dbg::MemSize))]
 pub struct M128Reg<const REGISTERS: usize> {
     registers: [HiLoRegister; REGISTERS],
 }

--- a/src/h2b/sketch.rs
+++ b/src/h2b/sketch.rs
@@ -43,8 +43,7 @@ impl Sketch for M64 {
     #[inline]
     #[allow(clippy::cast_possible_truncation)]
     fn val(&self, stream: u32) -> u8 {
-        debug_assert!(stream 
-          Self::STREAMS);
+        debug_assert!(stream < Self::STREAMS);
         let high_bit = (self.high >> stream) as u8 & 1;
         let low_bit = (self.low >> stream) as u8 & 1;
         high_bit << 1 | low_bit
@@ -163,6 +162,7 @@ impl Sketch for M128 {
 /// to optimize for cache locallity when compiting inside
 /// a vectored sketch
 #[derive(Default, Clone, Copy, Debug, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemDbg, mem_dbg::MemSize))]
 struct HiLoRegister {
     high: u128,
     low: u128,

--- a/src/h3b.rs
+++ b/src/h3b.rs
@@ -12,6 +12,7 @@ use crate::AHasherDefaultBuilder;
 /// different numbers of sub streams.
 ///
 /// Both the hasher and the sub stream size siaz can be customized, by default it uses `AHasherBuilder` and `M256`
+#[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemDbg, mem_dbg::MemSize))]
 pub struct HyperThreeBits<SKETCH: Sketch = M256, HASH: BuildHasher = AHasherDefaultBuilder> {
     hash: HASH,
     sketch: SKETCH,

--- a/src/h3b/sketch.rs
+++ b/src/h3b/sketch.rs
@@ -40,6 +40,7 @@ pub trait Sketch: Default {
 
 /// M = 64, using two 64 bit integers to store the sketch
 #[derive(Default)]
+#[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemDbg, mem_dbg::MemSize))]
 pub struct M64 {
     high: u64,
     middle: u64,
@@ -122,6 +123,7 @@ impl Sketch for M64 {
 ///
 /// The implementation is similar to M64
 #[derive(Default)]
+#[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemDbg, mem_dbg::MemSize))]
 pub struct M128 {
     low: u128,
     middle: u128,
@@ -193,6 +195,7 @@ impl Sketch for M128 {
 /// to optimize for cache locallity when compiting inside
 /// a vectored sketch
 #[derive(Default, Clone, Copy, Debug)]
+#[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemDbg, mem_dbg::MemSize))]
 struct BitRegister {
     high: u128,
     middle: u128,
@@ -203,6 +206,7 @@ struct BitRegister {
 ///
 /// This is not meant to be used directly instead it serves as
 /// a base for the other vectored sketches
+#[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemDbg, mem_dbg::MemSize))]
 pub struct M128Reg<const REGISTERS: usize> {
     registers: [BitRegister; REGISTERS],
 }

--- a/src/hbb64.rs
+++ b/src/hbb64.rs
@@ -1,6 +1,7 @@
 use std::hash::Hasher;
 
 /// `HyperBitBit` cardinality counter with 64 substreams
+#[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemDbg, mem_dbg::MemSize))]
 pub struct HyperBitBit64<HASH: Hasher + Default = ahash::AHasher> {
     _hash: std::marker::PhantomData<HASH>,
     sketch1: u64,

--- a/src/hyper_two_bits.rs
+++ b/src/hyper_two_bits.rs
@@ -9,6 +9,7 @@ use sketch::Sketch;
 use crate::M256;
 
 /// Random Seeded `AHasher` Builder that allows for seeded hashing per `HyperTwoBit` isnstance
+#[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemDbg, mem_dbg::MemSize))]
 pub struct AHasherBuilder {
     state: u64,
 }
@@ -36,6 +37,7 @@ pub type AHasherDefaultBuilder = BuildHasherDefault<ahash::AHasher>;
 
 /// Random Seeded `SipHasher13` Builder
 #[cfg(feature = "siphash")]
+#[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemDbg, mem_dbg::MemSize))]
 pub struct SipHasher13Builder {
     state: u64,
 }
@@ -65,6 +67,7 @@ pub type SipHasher13DefaultBuilder = BuildHasherDefault<siphasher::sip::SipHashe
 /// different numbers of sub streams.
 ///
 /// Both the hasher and the sub stream size siaz can be customized, by default it uses `AHasherBuilder` and `M256`
+#[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemDbg, mem_dbg::MemSize))]
 pub struct HyperTwoBits<SKETCH: Sketch = M256, HASH: BuildHasher = AHasherDefaultBuilder> {
     hash: HASH,
     sketch: SKETCH,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ use std::hash::{BuildHasher, BuildHasherDefault, Hasher as _};
 pub use prelude::*;
 
 /// Random Seeded `AHasher` Builder that allows for seeded hashing per `HyperTwoBit` isnstance
+#[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemDbg, mem_dbg::MemSize))]
 pub struct AHasherBuilder {
     state: u64,
 }
@@ -57,6 +58,7 @@ pub type AHasherDefaultBuilder = BuildHasherDefault<ahash::AHasher>;
 
 /// Random Seeded `SipHasher13` Builder
 #[cfg(feature = "siphash")]
+#[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemDbg, mem_dbg::MemSize))]
 pub struct SipHasher13Builder {
     state: u64,
 }


### PR DESCRIPTION
Added support as an optional feature to [mem_dbg](https://crates.io/crates/mem_dbg), an easy way to compute memory requirements for a struct. It is useful for comparing this library with other implementations.